### PR TITLE
Add few string helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 *.lock
+/.idea

--- a/README.md
+++ b/README.md
@@ -48,3 +48,26 @@ You can use this helper for alternating.
         echo Str::alternator('one', 'two', 'three', 'four', 'five');
       }
 ```
+#### Title Case
+You can use this helper for making a string or array of strings title case.
+
+```php
+    $data = 'test strinG';
+    Str::title_case($data);
+```
+ 
+#### Limit
+You can use this helper to limit a string or array of strings up to specified length.
+
+```php
+    $data = 'test string';
+    Str::limit($data, 4);
+```
+
+#### Contains
+You can use this helper to check if specific word or key exists in a string.
+
+```php
+    $data = 'test string';
+    Str::contains($data, 'test');
+```

--- a/example/index.php
+++ b/example/index.php
@@ -47,3 +47,37 @@ var_dump(Str::strip_slashes($arr_str))."\n";
 for ($i = 0; $i < 10; $i++) {
     echo Str::alternator('one', 'two', 'three', 'four', 'five', 'six');
 }
+
+//
+// Example Title Case
+//
+$string = 'hello world';
+$arr_str = [
+  'hello test',
+  'hEllo 4 tEst'
+];
+//String
+echo Str::title_case($string);
+// Array
+var_dump(Str::title_case($arr_str));
+
+//
+// Example Limit
+//
+$string = 'hello world';
+$arr_str = [
+    'hello test',
+    'hEllo 4 tEst'
+];
+//String
+echo Str::limit($string, 2);
+// Array
+var_dump(Str::limit($arr_str, 3));
+
+//
+// Example Contains
+//
+$string = 'hello world';
+// String
+var_dump(Str::contains($string, 'hell'));
+

--- a/src/Str.php
+++ b/src/Str.php
@@ -115,4 +115,48 @@ class Str
     {
         return substr((string)$haystack, 0, strlen($needle)) === (string) $needle;
     }
+
+    /**
+     * @param $str
+     * @return array|string
+     */
+    public static function title_case($str)
+    {
+        if (!is_array($str)) {
+            return ucwords(strtolower($str));
+        }
+        foreach ($str as $key => $value) {
+            $str[$key] = ucwords(strtolower($value));
+        }
+        return $str;
+    }
+
+    /**
+     * @param $str
+     * @param $limit
+     * @return array|bool|string
+     */
+    public static function limit($str, $limit)
+    {
+        if (!is_array($str)) {
+            return substr($str, 0, $limit);
+        }
+        foreach ($str as $key => $value) {
+            $str[$key] = substr($value, 0, $limit);
+        }
+        return $str;
+    }
+
+    /**
+     * @param $str
+     * @param $key
+     * @return bool
+     */
+    public static function contains($str, $key)
+    {
+        if (!is_string($str)) {
+            return false;
+        }
+        return strpos($str, $key) !== false;
+    }
 }

--- a/tests/StrTest/ContainsTest.php
+++ b/tests/StrTest/ContainsTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StrTest;
+
+use Str;
+use PHPUnit\Framework\TestCase;
+
+class ContainsTest extends TestCase
+{
+    public function testString()
+    {
+        $this->assertTrue(Str::contains("Today is a beautiful day.", 'beauti') === true);
+        $this->assertFalse(Str::contains("Today is a beautiful day.", 'beauty') === true);
+    }
+}

--- a/tests/StrTest/LimitTest.php
+++ b/tests/StrTest/LimitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace StrTest;
+
+use Str;
+use PHPUnit\Framework\TestCase;
+
+class LimitTest extends TestCase
+{
+    public function testString()
+    {
+        $this->assertTrue(Str::limit("Today is a beautiful day.", 8) === "Today is");
+    }
+
+    public function testArray()
+    {
+        $this->assertTrue(
+            Str::limit(
+                [
+                    "Winter is coming.",
+                    "abrakadabra",
+                    "Open source all the way."
+                ],
+                3
+            ) ===
+            [
+                "Win",
+                "abr",
+                "Ope"
+            ]
+        );
+    }
+}

--- a/tests/StrTest/TitleCaseTest.php
+++ b/tests/StrTest/TitleCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace StrTest;
+
+use Str;
+use PHPUnit\Framework\TestCase;
+
+class TitleCaseTest extends TestCase
+{
+    public function testString()
+    {
+        $this->assertTrue(Str::title_case("hello world") === "Hello World");
+    }
+
+    public function testArray()
+    {
+        $this->assertTrue(
+            Str::title_case(
+                [
+                    "hello from superman",
+                    "hi from batman!!",
+                    "namaste 2 times from ironMan"
+                ]
+            ) ===
+            [
+                "Hello From Superman",
+                "Hi From Batman!!",
+                "Namaste 2 Times From Ironman"
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This PR is for [this issue](https://github.com/ppabcd/Helpers/issues/2)
* Added String Helpers
- [x] Title Case
- [x] Limit
- [x] Contains

#### Title Case
```php
    $data = 'test strinG';
    Str::title_case($data);
    // Test String
```
#### Limit
```php
    $data = 'test string';
    Str::limit($data, 4);
    // test
```

#### Contains
```php
    $data = 'test string';
    Str::contains($data, 'test');
    // true
```