### PR TITLE
Added camelize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ You can use this helper for making a string or array of strings title case.
     Str::title_case($data);
     // Test String
 ```
- 
+
 #### Limit
 You can use this helper to limit a string or array of strings up to specified length.
 
 ```php
     $data = 'test string';
     Str::limit($data, 4);
-    // test 
+    // test
 ```
 
 #### Contains
@@ -87,4 +87,13 @@ You can use this helper to check if specific word or key exists in a string.
     $data = 'test string';
     Str::contains($data, 'test');
     // true
+```
+
+#### Camelize
+You can use this helper to camelize a string.
+
+```php
+    $data = 'example_test-string';
+    Str::camelize($data);
+    // ExampleTestString
 ```

--- a/example/index.php
+++ b/example/index.php
@@ -93,3 +93,10 @@ var_dump(Str::limit($arr_str, 3));
 $string = 'hello world';
 // String
 var_dump(Str::contains($string, 'hell'));
+
+//
+// Example camelize
+//
+$string = 'hello-world_example test';
+// String
+var_dump(Str::camelize($string));

--- a/src/Str.php
+++ b/src/Str.php
@@ -173,4 +173,19 @@ class Str
         }
         return strpos($str, $key) !== false;
     }
+
+    /**
+     * camelize string
+     * eg. this_is_my_string => ThisIsMyString
+     *
+     * @param  string $str
+     * @param  string $encoding
+     * @return string
+     */
+    public static function camelize($str, $encoding = 'UTF-8')
+    {
+        $str = str_replace(array('_','-'), ' ', trim(strtolower($str)));
+        $str = mb_convert_case($str, MB_CASE_TITLE, $encoding);
+        return preg_replace('!\s+!', '', $str);
+    }
 }

--- a/tests/StrTest/CamelizeTest.php
+++ b/tests/StrTest/CamelizeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace StrTest;
+
+use Str;
+use PHPUnit\Framework\TestCase;
+
+class CamelizeTest extends TestCase
+{
+    public function testString()
+    {
+        $this->assertTrue(Str::camelize("hello_world") === "HelloWorld");
+        $this->assertTrue(Str::camelize("i_am_an_example_string") === "IAmAnExampleString");
+
+        $this->assertTrue(Str::camelize("hello-world") === "HelloWorld");
+        $this->assertTrue(Str::camelize("i-am-an-example-string") === "IAmAnExampleString");
+    }
+}


### PR DESCRIPTION
This is for Issue #2 

**Usage**
```php
$string = 'hello_world_example_string';
echo Str::camelize($string);

// HelloWorldExampleString

$string = 'hello-world_example-string another words';
echo Str::camelize($string);

// HelloWorldExampleStringAnotherWords
```
**This PR contains:**
- [x] Implementation
- [x] UnitTest
- [x] Example
- [x] Documentation